### PR TITLE
ci(renovate): set baseBranchPatterns to develop for git-flow

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranchPatterns": ["main"],
+  "baseBranchPatterns": ["develop"],
   "configMigration": true,
   "constraints": {
     "bun": "1.3.14"


### PR DESCRIPTION
## Summary
- Switches Renovate's `baseBranchPatterns` from `["main"]` to `["develop"]`.
- Aligns the repo with the `dev-policies--git-flow` policy (main / develop / feature/*).

## Context
- Tracker: BRA-3347 (audit BRA-3346).
- `develop` branch was created from `main@57dee5e` for git-flow.
- Future PRs (Renovate or otherwise) must target `develop`.

## Test plan
- [x] `develop` exists at GitHub.
- [x] `renovate.json` parses (JSON valid).
- [ ] Next Renovate run opens PRs against `develop`.
- [ ] Default branch flipped to `develop` after this merges.