### PR TITLE
fix(renovate): add automergeStrategy squash and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# postcss-no-important
+
+PostCSS plugin that removes `!important` declarations from CSS.
+
+## Development
+
+This project uses [mise](https://mise.jdx.dev/) for tool management and [Bun](https://bun.sh/) as the JavaScript runtime.
+
+### Setup
+
+```bash
+mise install
+bun install
+```
+
+### Commands
+
+```bash
+bun test        # run tests
+bun run build   # build the package
+```
+
+### Contributing
+
+Follow [Brainders development policies](https://github.com/DUBANGARCIA/postcss-no-important/blob/develop/CONTRIBUTING.md):
+- Semantic commits (czg / commitlint)
+- Git Flow branching (feature/* → develop → main)
+- All changes via Pull Request — no direct push to main/develop

--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,7 @@
   "rangeStrategy": "pin",
   "semanticCommitScope": "workspace",
   "semanticCommits": "enabled",
+  "automergeStrategy": "squash",
   "timezone": "America/Chicago",
   "schedule": "After 7am every weekday"
 }


### PR DESCRIPTION
## Summary

Adds missing `automergeStrategy: squash` to `renovate.json` and adds `CLAUDE.md` as required by Brainders development policies ([BRA-8](https://github.com/DUBANGARCIA/postcss-no-important)).

Changes:
- `renovate.json`: adds `"automergeStrategy": "squash"` to align with Brainders Renovate policy
- `CLAUDE.md`: adds agent/developer quick-start guide (required by BRA-8 checklist)

## Related

- Audit issue: BRA-3509
- Policy source: BRA-8 (Brainders Dev Policies)

## Test plan

- [ ] Verify `renovate.json` passes schema validation
- [ ] Confirm `CLAUDE.md` renders correctly on GitHub