### PR TITLE
feat(ci): add Trivy FS security scan (BRA-3657)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,19 @@ jobs:
           name: ${{ matrix.os }}-node
           fail_ci_if_error: false
 
+  security:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'develop')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+
+      - name: Security scan (Trivy)
+        run: mise exec -- trivy fs --exit-code 1 --severity CRITICAL,HIGH .
+
   coverage-summary:
     needs: test
     runs-on: ubuntu-latest

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
+  "aqua:aquasecurity/trivy"    = "0.71.1"
   "aqua:evilmartians/lefthook" = "2.1.9"
   "aqua:koalaman/shellcheck"   = "0.11.0"
   "aqua:nektos/act"            = "0.2.89"


### PR DESCRIPTION
## Summary

- Adds a parallel `security` job to `.github/workflows/test.yml` that runs Trivy filesystem scan
- Scoped to PRs targeting `main` or `develop` (via job-level `if` condition)
- Fails on `CRITICAL` or `HIGH` severity findings per [BRA-8](/BRA/issues/BRA-8) policy
- Adds `aqua:aquasecurity/trivy = "0.71.1"` to `mise.toml` for local and CI use
- Uses `jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac` (v2, commit-pinned) to set up mise in CI

## Test plan

- [ ] PR passes existing test/build jobs unaffected
- [ ] `security` job appears in CI and runs `trivy fs --exit-code 1 --severity CRITICAL,HIGH .`
- [ ] Verify `mise exec -- trivy fs --exit-code 1 --severity CRITICAL,HIGH .` locally after `mise install`
- [ ] Coordinate rename to `.yaml` extension when [BRA-3651](/BRA/issues/BRA-3651) is merged to develop

Refs [BRA-3657](/BRA/issues/BRA-3657), [BRA-3650](/BRA/issues/BRA-3650), [BRA-8](/BRA/issues/BRA-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)