### PR TITLE
chore(lefthook): wrap bun invocations with `mise exec --` (BRA-3774)

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -8,22 +8,22 @@ pre-commit:
     format:
       priority: 1
       glob: '*'
-      run: bun --bun biome format --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      run: mise exec -- bun --bun biome format --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
       stage_fixed: true
     lint:
       priority: 2
       glob: '*'
-      run: bun --bun biome lint --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      run: mise exec -- bun --bun biome lint --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
       stage_fixed: true
     sort-package-json:
       priority: 3
       glob: '**/package.json'
-      run: bun sort-package-json {staged_files}
+      run: mise exec -- bun sort-package-json {staged_files}
       stage_fixed: true
     toml:
       priority: 4
       glob: '*.toml'
-      run: bun --bun taplo fmt {staged_files}
+      run: mise exec -- bun --bun taplo fmt {staged_files}
       stage_fixed: true
     actionlint:
       priority: 2
@@ -38,7 +38,7 @@ commit-msg:
     - run: eval "$(mise env)"
   commands:
     commitlint:
-      run: bun --bun commitlint --config commitlint.config.js --edit "$1"
+      run: mise exec -- bun --bun commitlint --config commitlint.config.js --edit "$1"
 
 post-checkout, post-merge, post-rewrite:
   parallel: false
@@ -49,6 +49,6 @@ post-checkout, post-merge, post-rewrite:
   commands:
     bun-install:
       glob: "{package.json,bun.lock,bunfig.toml}"
-      run: bun install --frozen-lockfile
+      run: mise exec -- bun install --frozen-lockfile
       only:
         - changed


### PR DESCRIPTION
## Summary

Per **dev-policies--cross-platform** / BRA-8 ([audit BRA-3772](/BRA/issues/BRA-3772) → remediation [BRA-3774](/BRA/issues/BRA-3774)):
all `bun` invocations in `lefthook.yaml` must run through `mise exec --` so the version pinned in `mise.toml`/`mise.lock` is used, not whatever `bun` is on `PATH`.

## Changes

`lefthook.yaml` only — six commands wrapped:

| Hook                                       | Command          | Before                       | After                                    |
| ------------------------------------------ | ---------------- | ---------------------------- | ---------------------------------------- |
| pre-commit                                 | format           | `bun --bun biome format …`   | `mise exec -- bun --bun biome format …`  |
| pre-commit                                 | lint             | `bun --bun biome lint …`     | `mise exec -- bun --bun biome lint …`    |
| pre-commit                                 | sort-package-json| `bun sort-package-json …`    | `mise exec -- bun sort-package-json …`   |
| pre-commit                                 | toml             | `bun --bun taplo fmt …`      | `mise exec -- bun --bun taplo fmt …`     |
| commit-msg                                 | commitlint       | `bun --bun commitlint …`     | `mise exec -- bun --bun commitlint …`    |
| post-checkout / post-merge / post-rewrite  | bun-install      | `bun install …`              | `mise exec -- bun install …`             |

`actionlint` left unwrapped — it's an aqua-managed binary invoked directly, not via bun.

## Notes

- `commitlint.config.js` reference left untouched on purpose — [PR #635 (BRA-3349)](https://github.com/DUBANGARCIA/postcss-no-important/pull/635) is the owner of the `.js → .cjs` rename. After #635 lands, that single line will need updating; trivial follow-up.
- No tests change — lefthook only affects local hook execution.

## Test plan

- [ ] Open PR triggers CI workflows (`build`, `test`, `dependency-review`)
- [ ] Local `lefthook run pre-commit` resolves `bun` through `mise exec` (verify by setting a non-pinned `bun` on PATH)